### PR TITLE
preload env for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Backend Challenges Boilerplate - Basic Express
 [![Run on Repl.it](https://repl.it/badge/github/freeCodeCamp/boilerplate-express)](https://repl.it/github/freeCodeCamp/boilerplate-express)
+
+# When Developing on your Local Machine
+1) run `npm ci`
+2) `npm run start-local` (this preloads the environment variables set up in your `.env` file)

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,12 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
+		"dotenv": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+			"dev": true
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,13 @@
 		"cookie-parser": "^1.4.3",
 		"fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git"
 	},
+	"devDependencies": {
+		"dotenv": "8.2.0"
+	},
 	"main": "server.js",
 	"scripts": {
-		"start": "node server.js"
+		"start": "node server.js",
+		"start-local": "node -r dotenv/config server.js"
 	},
 	"engines": {
 		"node": "4.4.5"


### PR DESCRIPTION
fixes the template for local development, as per bug described here: https://github.com/freeCodeCamp/freeCodeCamp/issues/39765

This pr: 
- preloads the environment variables rather than requiring them at runtime which reduces the number of runtime dependencies in application (keep app dependencies small is a good habit to have and start early on! : ))
- it creates a separate script for local development, which ensures that repl.it is not preloading env variables twice (in their docs they mention that they do this step automatically for apps: https://github.com/replit/replit.github.io/blob/eeeff3dae49414067398ed2c413e19938b182c6d/repls/secret-keys.md#reading-env-files)

A really nice article about handling node environment variables, which inspired me to approach it this way rather than including a 'require' in the code: https://medium.com/the-node-js-collection/making-your-node-js-work-everywhere-with-environment-variables-2da8cdf6e786