### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
 	"main": "server.js",
 	"scripts": {
 		"start": "node server.js"
-	},
-	"engines": {
-		"node": "4.4.5"
 	}
 }


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365