### PR TITLE
fix: change style.css reference to public/style.css

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
 		<title>Hello HTML</title>
-		<link rel="stylesheet" href="/style.css">
+		<link rel="stylesheet" href="/public/style.css">
 	</head>
 	<body>
 		<h1>Hello, HTML.</h1>


### PR DESCRIPTION
This is indeed a side effect of fixing an issue in the curriculum. Basically I think the public folder should have its own folder and it should not be mounted to root. This is both nonstandard and confusing. Thus this PR works paired with this one: https://github.com/freeCodeCamp/freeCodeCamp/pull/40802