### PR TITLE
fix: preinstall dotenv for local development, pretty JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"body-parser": "^1.15.2",
 				"cookie-parser": "^1.4.3",
+				"dotenv": "^16.0.1",
 				"express": "^4.14.0",
 				"fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git"
 			}
@@ -141,6 +142,14 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+			"integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/ee-first": {
@@ -713,6 +722,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
 			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+		},
+		"dotenv": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+			"integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
 		},
 		"ee-first": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
 	"name": "fcc-learn-node-with-express",
 	"version": "0.1.0",
 	"dependencies": {
-		"express": "^4.14.0",
 		"body-parser": "^1.15.2",
 		"cookie-parser": "^1.4.3",
+		"dotenv": "^16.0.1",
+		"express": "^4.14.0",
 		"fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git"
 	},
 	"main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-	"name": "fcc-learn-node-with-express",
-	"version": "0.1.0",
-	"dependencies": {
-		"body-parser": "^1.15.2",
-		"cookie-parser": "^1.4.3",
-		"dotenv": "^16.0.1",
-		"express": "^4.14.0",
-		"fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git"
-	},
-	"main": "server.js",
-	"scripts": {
-		"start": "node server.js"
-	}
+  "name": "fcc-learn-node-with-express",
+  "version": "0.1.0",
+  "dependencies": {
+    "body-parser": "^1.15.2",
+    "cookie-parser": "^1.4.3",
+    "dotenv": "^16.0.1",
+    "express": "^4.14.0",
+    "fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git"
+  },
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/46910

<!-- Feel free to add any additional description of changes below this line -->
The [Basic Node and Express](https://www.freecodecamp.org/learn/back-end-development-and-apis#basic-node-and-express) challenges instruct learners to install `dotenv` and `body-parser`.

`body-parser` is already listed in `package.json` as a dependency, so this PR just adds `dotenv`. However, since the instructional text makes it clear that `dotenv` is only necessary for local development, this PR might not be necessary.

This PR also pretties up `package.json` a bit. But again, it's not completely necessary.

If it's decided that these changes aren't needed, we can close this and I'll update https://github.com/freeCodeCamp/freeCodeCamp/pull/47048.